### PR TITLE
Fix blacklist

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,5 @@ curse_requirements=bookshelf
 curse_project=59413
 
 version_bookshelf=2.3.567
-version_minetweaker=4.1.9.491
+version_minetweaker=4.1.20.675
 version_jei=4.13.1.220

--- a/src/main/java/net/darkhax/eplus/ConfigurationHandler.java
+++ b/src/main/java/net/darkhax/eplus/ConfigurationHandler.java
@@ -10,6 +10,7 @@ import net.darkhax.eplus.api.Blacklist;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.oredict.OreDictionary;
 
 public final class ConfigurationHandler {
 
@@ -44,7 +45,14 @@ public final class ConfigurationHandler {
 
     public static void buildBlacklist () {
 
-        for (final String itemString : blacklistedItems) {
+        for (String origString : blacklistedItems) {
+            
+            String itemString = origString;
+            if (!itemString.contains("#")) {
+                
+                # Default items to all metas
+                itemString = itemString + "#" + OreDictionary.WILDCARD_VALUE;
+            }
 
             final ItemStack stack = StackUtils.createStackFromString(itemString);
 

--- a/src/main/java/net/darkhax/eplus/api/Blacklist.java
+++ b/src/main/java/net/darkhax/eplus/api/Blacklist.java
@@ -30,7 +30,7 @@ public final class Blacklist {
 
         for (final ItemStack blacklisted : BLACKLIST_ITEMS) {
 
-            if (StackUtils.areStacksSimilarWithPartialNBT(blacklisted, stack)) {
+            if (StackUtils.areStacksSimilar(blacklisted, stack)) {
 
                 return true;
             }

--- a/src/main/java/net/darkhax/eplus/compat/crt/EnchantingPlusCRT.java
+++ b/src/main/java/net/darkhax/eplus/compat/crt/EnchantingPlusCRT.java
@@ -6,6 +6,7 @@ import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.enchantments.IEnchantment;
 import crafttweaker.api.item.IItemStack;
 import net.darkhax.eplus.api.Blacklist;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
@@ -38,7 +39,7 @@ public class EnchantingPlusCRT {
         @Override
         public void apply () {
 
-            Blacklist.blacklist((ItemStack) this.item.getDefinition().getInternal());
+            Blacklist.blacklist(new ItemStack((Item) this.item.getDefinition().getInternal()));
         }
 
         @Override

--- a/src/main/java/net/darkhax/eplus/compat/crt/EnchantingPlusCRT.java
+++ b/src/main/java/net/darkhax/eplus/compat/crt/EnchantingPlusCRT.java
@@ -5,7 +5,9 @@ import crafttweaker.IAction;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.enchantments.IEnchantment;
 import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.minecraft.CraftTweakerMC;
 import net.darkhax.eplus.api.Blacklist;
+import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import stanhebben.zenscript.annotations.ZenClass;
@@ -24,7 +26,7 @@ public class EnchantingPlusCRT {
     @ZenMethod
     public static void blacklistEnchantment (IEnchantment enchantment) {
 
-        CraftTweakerAPI.apply(new ActionBlacklist(enchantment));
+        CraftTweakerAPI.apply(new ActionBlacklistEnch(enchantment));
     }
 
     private static class ActionBlacklistItem implements IAction {
@@ -39,7 +41,7 @@ public class EnchantingPlusCRT {
         @Override
         public void apply () {
 
-            Blacklist.blacklist(new ItemStack((Item) this.item.getDefinition().getInternal()));
+            Blacklist.blacklist(CraftTweakerMC.getItemStack(this.item));
         }
 
         @Override
@@ -49,11 +51,11 @@ public class EnchantingPlusCRT {
         }
     }
 
-    private static class ActionBlacklist implements IAction {
+    private static class ActionBlacklistEnch implements IAction {
 
         private final IEnchantment enchantment;
 
-        public ActionBlacklist (IEnchantment enchantment) {
+        public ActionBlacklistEnch (IEnchantment enchantment) {
 
             this.enchantment = enchantment;
         }
@@ -61,7 +63,7 @@ public class EnchantingPlusCRT {
         @Override
         public void apply () {
 
-            Blacklist.blacklist((ItemStack) this.enchantment.getDefinition().getInternal());
+            Blacklist.blacklist((Enchantment) this.enchantment.getDefinition().getInternal());
         }
 
         @Override

--- a/src/main/java/net/darkhax/eplus/gui/GuiEnchantmentLabel.java
+++ b/src/main/java/net/darkhax/eplus/gui/GuiEnchantmentLabel.java
@@ -109,7 +109,6 @@ public class GuiEnchantmentLabel extends Gui {
      * the enchantment being represented.
      *
      * @param xPos The xPos of the slider.
-     * @param baseX The previous slider position.
      */
     public void updateSlider (int xPos) {
 


### PR DESCRIPTION
Related to https://github.com/Epoxide-Software/Enchanting-Plus/pull/165.

This should fix https://github.com/Epoxide-Software/Enchanting-Plus/issues/161 by not checking for similar NBT tags. This allows modded installs to function properly (since you can't specify NBT in the configuration file). CraftTweaker blacklist is also fixed, and the durability tweaks should be made to allow durability to be specified (or left unspecified as a wildcard durability). 